### PR TITLE
 feat: integrate procd init system, robust updater script, and UCI config

### DIFF
--- a/sqm-autorate-rust/Makefile
+++ b/sqm-autorate-rust/Makefile
@@ -59,7 +59,7 @@ define Package/sqm-autorate-rust/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/reflectors-icmp.csv $(1)/usr/share/sqm-autorate/reflectors-icmp.csv
 
 	# Create the symlink the Rust binary expects (points to RAM)
-	ln -sf /tmp/reflectors-icmp.csv $(1)/etc/sqm-autorate/reflectors-icmp.csv
+	ln -sf /var/run/sqm-autorate/reflectors-icmp.csv $(1)/etc/sqm-autorate/reflectors-icmp.csv
 endef
 
 $(eval $(call BuildPackage,sqm-autorate-rust))

--- a/sqm-autorate-rust/Makefile
+++ b/sqm-autorate-rust/Makefile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 # Copyright (C) 2023 Nils Andreas Svee
+# Copyright (C) 2026 Fabio Rieker
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqm-autorate-rust
 PKG_VERSION:=0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Lochnair/sqm-autorate-rust
-PKG_SOURCE_VERSION:=4a1368cd7ae4ad9960fcdf4a2f42672f49863fad
+PKG_SOURCE_VERSION:=7d833ecff8b69c12fdcbe5da64c6cfc74b3dc720
 
 PKG_MAINTAINER:=Nils Andreas Svee <me@lochnair.net>
 PKG_LICENSE:=MPL
@@ -25,11 +26,11 @@ define Build/Compile
 endef
 
 define Package/sqm-autorate-rust
-  SECTION:=utils
-  CATEGORY:=Utilities
-  TITLE:=sqm autorate (rust)
-  DEPENDS:=$(RUST_ARCH_DEPENDS)
-  URL:=https://github.com/Lochnair/sqm-autorate-rust
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=sqm autorate (rust)
+	DEPENDS:=$(RUST_ARCH_DEPENDS)
+	URL:=https://github.com/Lochnair/sqm-autorate-rust
 endef
 
 define Package/sqm-autorate-rust/description
@@ -37,8 +38,28 @@ define Package/sqm-autorate-rust/description
 endef
 
 define Package/sqm-autorate-rust/install
+	# 2. Fix the path for the new standard rust behaviour: Point to 'release' instead of 'stripped'
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/target/$(RUSTC_TARGET_ARCH)/stripped/sqm-autorate-rust $(1)/usr/sbin/sqm-autorate-rust
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/target/$(RUSTC_TARGET_ARCH)/release/sqm-autorate-rust $(1)/usr/sbin/sqm-autorate-rust
+
+	# Create necessary configuration and state directories
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/sqm-autorate
+	$(INSTALL_DIR) $(1)/usr/share/sqm-autorate
+
+	# Install init and update scripts (chmod 755)
+	$(INSTALL_BIN) ./files/sqm-autorate.init $(1)/etc/init.d/sqm-autorate
+	$(INSTALL_BIN) ./files/sqm-autorate-update.sh $(1)/usr/sbin/sqm-autorate-update
+
+	# Install sample config (chmod 600)
+	$(INSTALL_CONF) ./files/sqm-autorate.sample $(1)/etc/config/sqm-autorate.sample
+
+	# Install ROM fallback data (chmod 644)
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/reflectors-icmp.csv $(1)/usr/share/sqm-autorate/reflectors-icmp.csv
+
+	# Create the symlink the Rust binary expects (points to RAM)
+	ln -sf /tmp/reflectors-icmp.csv $(1)/etc/sqm-autorate/reflectors-icmp.csv
 endef
 
 $(eval $(call BuildPackage,sqm-autorate-rust))

--- a/sqm-autorate-rust/files/sqm-autorate-update.sh
+++ b/sqm-autorate-rust/files/sqm-autorate-update.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2023 Nils Andreas Svee
+# Copyright (C) 2026 Fabio Rieker
+
+
+URL="https://raw.githubusercontent.com/Lochnair/sqm-autorate-rust/master/reflectors-icmp.csv"
+RAM_FILE="/tmp/reflectors-icmp.csv"
+TMP_FILE="/tmp/reflectors-icmp.csv.new"
+
+
+# The reflectors file is so tiny,
+# that checking if it got updated basically causes the same trafick than just downloading it.
+# Ergo, I decided pulling it once a day is sustainabel enought. 
+
+# Configuration
+MAX_RETRIES=3
+RETRY_DELAY=30  # Seconds
+MIN_SIZE=2048   # 2KB minimum
+STALE_IN_DAYS=3
+
+update_success=0
+attempt=1
+
+# 1. Atomic Download Loop
+while [ $attempt -le $MAX_RETRIES ]; do
+    if wget -q -O "$TMP_FILE" "$URL"; then
+        FILE_SIZE=$(wc -c < "$TMP_FILE")
+        
+        if [ "$FILE_SIZE" -gt "$MIN_SIZE" ]; then
+            mv "$TMP_FILE" "$RAM_FILE"
+            logger -t sqm-autorate "INFO: Reflectors updated successfully ($FILE_SIZE bytes ... will now restart sqm-autorate)."
+            /etc/init.d/sqm-autorate restart
+            update_success=1
+            break
+        fi
+    fi
+    
+    # Silently increment and wait. No log spam.
+    attempt=$((attempt + 1))
+    [ $attempt -le $MAX_RETRIES ] && sleep $RETRY_DELAY
+done
+
+# 2. Total Failure Handling (Stale Check)
+if [ "$update_success" -ne 1 ]; then
+    rm -f "$TMP_FILE"
+    
+    CURRENT_TIME=$(date +%s)
+    FILE_TIME=$(date -r "$RAM_FILE" +%s)
+    
+    # Calculate difference in seconds, then convert to integer days
+    AGE_SEC=$((CURRENT_TIME - FILE_TIME))
+    AGE_DAYS=$((AGE_SEC / 86400))
+
+    # Use -ge (greater than or equal to) because 3.1 days becomes 3 days
+    if [ "$AGE_DAYS" -ge "$STALE_IN_DAYS" ]; then
+        logger -t sqm-autorate "WARNING: Reflectors are STALE, update failed. Active list is $AGE_DAYS days old (Threshold: $STALE_DAYS)!"
+    else
+        logger -t sqm-autorate "INFO: Reflector update failed. Continuing with existing list."
+    fi
+fi

--- a/sqm-autorate-rust/files/sqm-autorate-update.sh
+++ b/sqm-autorate-rust/files/sqm-autorate-update.sh
@@ -7,13 +7,17 @@
 
 
 URL="https://raw.githubusercontent.com/Lochnair/sqm-autorate-rust/master/reflectors-icmp.csv"
-RAM_FILE="/tmp/reflectors-icmp.csv"
-TMP_FILE="/tmp/reflectors-icmp.csv.new"
+RUN_DIR="/var/run/sqm-autorate"
+RAM_FILE="$RUN_DIR/reflectors-icmp.csv"
+# Generating temporary files in the same directory as their target guarantees that
+# standard \`mv\` commands perform a purely atomic kernel rename() operation.
+# This ensures zero window where the Rust binary could read a partially written file.
+TMP_FILE="$RUN_DIR/reflectors-icmp.csv.new"
 
 
 # The reflectors file is so tiny,
-# that checking if it got updated basically causes the same trafick than just downloading it.
-# Ergo, I decided pulling it once a day is sustainabel enought. 
+# that checking if it got updated basically causes the same traffic than just downloading it.
+# Ergo, I decided pulling it once a day is sustainable enough. 
 
 # Configuration
 MAX_RETRIES=3
@@ -25,6 +29,8 @@ update_success=0
 attempt=1
 
 # 1. Atomic Download Loop
+mkdir -p "$RUN_DIR"
+
 while [ $attempt -le $MAX_RETRIES ]; do
     if wget -q -O "$TMP_FILE" "$URL"; then
         FILE_SIZE=$(wc -c < "$TMP_FILE")
@@ -47,17 +53,20 @@ done
 if [ "$update_success" -ne 1 ]; then
     rm -f "$TMP_FILE"
     
+    if [ ! -f "$RAM_FILE" ]; then
+        logger -t sqm-autorate "WARNING: Update failed & RAM copy of reflectors entirely missing! Restarting service to attemt self-heal."
+        /etc/init.d/sqm-autorate restart
+        exit 1
+    fi
+    
     CURRENT_TIME=$(date +%s)
     FILE_TIME=$(date -r "$RAM_FILE" +%s)
-    
-    # Calculate difference in seconds, then convert to integer days
-    AGE_SEC=$((CURRENT_TIME - FILE_TIME))
-    AGE_DAYS=$((AGE_SEC / 86400))
+    AGE_DAYS=$(( (CURRENT_TIME - FILE_TIME) / 86400 ))
 
     # Use -ge (greater than or equal to) because 3.1 days becomes 3 days
     if [ "$AGE_DAYS" -ge "$STALE_IN_DAYS" ]; then
         logger -t sqm-autorate "WARNING: Reflectors are STALE, update failed. Active list is $AGE_DAYS days old (Threshold: $STALE_DAYS)!"
     else
-        logger -t sqm-autorate "INFO: Reflector update failed. Continuing with existing list."
+        logger -t sqm-autorate "INFO: Update failed. Continuing with existing $AGE_DAYS days old list."
     fi
 fi

--- a/sqm-autorate-rust/files/sqm-autorate.init
+++ b/sqm-autorate-rust/files/sqm-autorate.init
@@ -1,0 +1,182 @@
+#!/bin/sh /etc/rc.common
+
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2023 Nils Andreas Svee
+# Copyright (C) 2026 Fabio Rieker
+
+
+
+USE_PROCD=1
+START=99
+
+PROG=/usr/sbin/sqm-autorate-rust
+CONFIG_FILE="/etc/config/sqm-autorate"
+SAMPLE_FILE="/etc/config/sqm-autorate.sample"
+
+# The binary expects it here; this is a symlink to RAM_FILE
+LINK_FILE="/etc/sqm-autorate/reflectors-icmp.csv"
+RAM_FILE="/tmp/reflectors-icmp.csv"
+ROM_FILE="/usr/share/sqm-autorate/reflectors-icmp.csv"
+
+CRON_FILE="/etc/crontabs/root"
+CRON_CMD="/usr/sbin/sqm-autorate-update"
+
+
+# 1. Environment Gatekeeper: Checks filesystem readiness and handles RAM sync
+validate_environment() {
+    # Check Config Existence (Hard fail - user action required)
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "=====================================================================" >&2
+        echo " FATAL ERROR: sqm-autorate configuration missing!" >&2
+        echo " " >&2
+        echo " You must create a configuration file before starting this service." >&2
+        echo " Run the following command to create a template, then edit it:" >&2
+        echo " cp $SAMPLE_FILE $CONFIG_FILE" >&2
+        echo "=====================================================================" >&2
+        
+        logger -t sqm-autorate "FATAL: Config file missing. Directed user to $SAMPLE_FILE."
+        return 1
+    fi
+
+    # Handle the RAM-based Reflector File
+    if [ ! -f "$RAM_FILE" ]; then
+        if [ -f "$ROM_FILE" ]; then
+            # Silent restoration - expected behavior after reboot
+            cp "$ROM_FILE" "$RAM_FILE"
+        else
+            echo " FATAL ERROR: ROM fallback missing at $ROM_FILE!" >&2
+            logger -t sqm-autorate "FATAL: Installation corrupt. $ROM_FILE is missing."
+            return 1
+        fi
+    elif [ ! -s "$RAM_FILE" ]; then
+        # File exists but is 0 bytes (Corruption case)
+        echo "=====================================================================" >&2
+        echo " WARNING: Reflector file in RAM is corrupt/empty!" >&2
+        echo " Automatically restoring from ROM fallback..." >&2
+        echo "=====================================================================" >&2
+        
+        logger -t sqm-autorate "WARNING: $RAM_FILE was empty. Restored from $ROM_FILE."
+        cp "$ROM_FILE" "$RAM_FILE"
+    fi
+
+    return 0
+}
+
+# 2. Config Gatekeeper: Ensures mandatory UCI values are present and interfaces exist
+    ## This should be done by the binarry via a check/validate flag, but till it suports it,
+    ## we will do it here, better than not having it
+validate_config() {
+    local dl_iface="$1"
+    local ul_iface="$2"
+    local dl_base="$3"
+    local ul_base="$4"
+    local dl_min="$5"
+    local ul_min="$6"
+
+    # 1. Check for missing mandatory variables
+    local missing=""
+    [ -z "$dl_iface" ] && missing="${missing} download_interface"
+    [ -z "$ul_iface" ] && missing="${missing} upload_interface"
+    [ -z "$dl_base" ]  && missing="${missing} download_base_kbits"
+    [ -z "$ul_base" ]  && missing="${missing} upload_base_kbits"
+
+    if [ -n "$missing" ]; then
+        echo "=====================================================================" >&2
+        echo " FATAL ERROR: Invalid sqm-autorate configuration!" >&2
+        echo " " >&2
+        echo " Missing mandatory options:$missing" >&2
+        echo "=====================================================================" >&2
+        logger -t sqm-autorate "FATAL: Configuration missing:$missing"
+        return 1
+    fi
+
+    # 2. Verify interfaces actually exist in the system kernel
+    for iface in "$dl_iface" "$ul_iface"; do
+        if [ ! -d "/sys/class/net/$iface" ]; then
+            echo " FATAL ERROR: Network interface '$iface' not found!" >&2
+            logger -t sqm-autorate "FATAL: Interface $iface does not exist."
+            return 1
+        fi
+    done
+
+    # 3. Validate that min_percent values are actually numbers (integers)
+    for val in "$dl_min" "$ul_min"; do
+        if ! [ "$val" -eq "$val" ] 2>/dev/null; then
+            echo " FATAL ERROR: min_percent values must be integers (got: $val)!" >&2
+            logger -t sqm-autorate "FATAL: Invalid min_percent value: $val"
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+manage_cron() {
+    local action="$1"
+    
+    # Always scrub existing entries first to prevent duplicates
+    sed -i '/sqm-autorate-update/d' "$CRON_FILE" 2>/dev/null
+    
+    if [ "$action" = "add" ]; then
+        # Generate a random minute (0-59) to spread out the load on the GitHub server.
+        # If $RANDOM is somehow missing in this specific OpenWrt build, fallback to 17.
+        local MIN=${RANDOM:-17}
+        MIN=$((MIN % 60))
+        
+        # Schedule between 4:00 AM and 4:59 AM
+        echo "$MIN 4 * * * $CRON_CMD >/dev/null 2>&1" >> "$CRON_FILE"
+    fi
+    
+    # Restart the busybox cron daemon so it sees the changes
+    /etc/init.d/cron restart
+}
+
+
+start_service() {
+    # Phase 1: Environment Readiness
+    validate_environment || return 1
+
+    # Phase 2: Load UCI Data
+    . /lib/functions.sh
+    config_load sqm-autorate
+    
+    local section="main"
+    config_get dl_iface "$section" download_interface
+    config_get ul_iface "$section" upload_interface
+    config_get dl_base  "$section" download_base_kbits
+    config_get ul_base  "$section" upload_base_kbits
+    config_get testing  "$section" testing "0"
+    config_get log_lvl  "$section" log_level "info"
+
+    # Phase 3: Config Validation, it would be better if the bin reads the conf file directly
+        ## And if we could call it with some check/validate flag so utilety scripts like this
+        ## can trigger manual checks
+    validate_config "$dl_iface" "$ul_iface" "$dl_base" "$ul_base" "$dl_min" "$ul_min" || return 1
+
+    # Add the Cron Job
+    manage_cron "add"
+
+    # Phase 4: Launch via Procd
+    procd_open_instance
+    procd_set_param command "$PROG"
+    
+    procd_set_param env \
+        SQMA_DOWNLOAD_INTERFACE="$dl_iface" \
+        SQMA_UPLOAD_INTERFACE="$ul_iface" \
+        SQMA_DOWNLOAD_BASE_KBITS="$dl_base" \
+        SQMA_UPLOAD_BASE_KBITS="$ul_base" \
+        SQMA_TESTING="$testing" \
+        SQMA_STATS_FILE="/var/run/sqm-autorate.json" \
+        RUST_LOG="$log_lvl"
+
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}
+
+stop_service() {
+    # Clean up the cron job when the service is stopped
+    manage_cron "remove"
+}

--- a/sqm-autorate-rust/files/sqm-autorate.init
+++ b/sqm-autorate-rust/files/sqm-autorate.init
@@ -5,8 +5,6 @@
 # Copyright (C) 2023 Nils Andreas Svee
 # Copyright (C) 2026 Fabio Rieker
 
-
-
 USE_PROCD=1
 START=99
 
@@ -14,17 +12,20 @@ PROG=/usr/sbin/sqm-autorate-rust
 CONFIG_FILE="/etc/config/sqm-autorate"
 SAMPLE_FILE="/etc/config/sqm-autorate.sample"
 
-# The binary expects it here; this is a symlink to RAM_FILE
+# FHS-Compliant Volatile Storage Paths
 LINK_FILE="/etc/sqm-autorate/reflectors-icmp.csv"
-RAM_FILE="/tmp/reflectors-icmp.csv"
+RAM_FILE="/var/run/sqm-autorate/reflectors-icmp.csv"
 ROM_FILE="/usr/share/sqm-autorate/reflectors-icmp.csv"
+STATS_FILE="/var/run/sqm-autorate/sqm-autorate.json"
 
 CRON_FILE="/etc/crontabs/root"
 CRON_CMD="/usr/sbin/sqm-autorate-update"
 
-
 # 1. Environment Gatekeeper: Checks filesystem readiness and handles RAM sync
 validate_environment() {
+    # Recreate the FHS-compliant runtime directory in RAM
+    mkdir -p /var/run/sqm-autorate
+
     # Check Config Existence (Hard fail - user action required)
     if [ ! -f "$CONFIG_FILE" ]; then
         echo "=====================================================================" >&2
@@ -64,8 +65,8 @@ validate_environment() {
 }
 
 # 2. Config Gatekeeper: Ensures mandatory UCI values are present and interfaces exist
-    ## This should be done by the binarry via a check/validate flag, but till it suports it,
-    ## we will do it here, better than not having it
+# Config checks should be done by the binary via a check/validate flag, but till it supports it,
+# we will do it here, better than not having it
 validate_config() {
     local dl_iface="$1"
     local ul_iface="$2"
@@ -132,7 +133,6 @@ manage_cron() {
     /etc/init.d/cron restart
 }
 
-
 start_service() {
     # Phase 1: Environment Readiness
     validate_environment || return 1
@@ -146,12 +146,15 @@ start_service() {
     config_get ul_iface "$section" upload_interface
     config_get dl_base  "$section" download_base_kbits
     config_get ul_base  "$section" upload_base_kbits
-    config_get testing  "$section" testing "0"
+    config_get dl_min   "$section" download_min_percent "20"
+    config_get ul_min   "$section" upload_min_percent "20"
+#    config_get testing  "$section" testing "1"     # Currently not suported by the binarry
     config_get log_lvl  "$section" log_level "info"
 
-    # Phase 3: Config Validation, it would be better if the bin reads the conf file directly
-        ## And if we could call it with some check/validate flag so utilety scripts like this
-        ## can trigger manual checks
+    # Phase 3: Config Validation
+    # It would be better if the bin reads the conf file directly.
+    # And if we could call it with some check/validate flag so utility scripts like this
+    # can trigger manual checks
     validate_config "$dl_iface" "$ul_iface" "$dl_base" "$ul_base" "$dl_min" "$ul_min" || return 1
 
     # Add the Cron Job
@@ -161,13 +164,16 @@ start_service() {
     procd_open_instance
     procd_set_param command "$PROG"
     
+#   SQMA_TESTING="$testing_bool" (Currently not supported by the binary)
     procd_set_param env \
         SQMA_DOWNLOAD_INTERFACE="$dl_iface" \
         SQMA_UPLOAD_INTERFACE="$ul_iface" \
         SQMA_DOWNLOAD_BASE_KBITS="$dl_base" \
         SQMA_UPLOAD_BASE_KBITS="$ul_base" \
-        SQMA_TESTING="$testing" \
-        SQMA_STATS_FILE="/var/run/sqm-autorate.json" \
+        SQMA_DOWNLOAD_MIN_PERCENT="$dl_min" \
+        SQMA_UPLOAD_MIN_PERCENT="$ul_min" \
+        SQMA_STATS_FILE="$STATS_FILE" \
+        SQMA_LOG_LEVEL="$log_lvl" \
         RUST_LOG="$log_lvl"
 
     procd_set_param stdout 1

--- a/sqm-autorate-rust/files/sqm-autorate.sample
+++ b/sqm-autorate-rust/files/sqm-autorate.sample
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2023 Nils Andreas Svee
+# Copyright (C) 2026 Fabio Rieker
+
+## This is a sample config for a symmetric gigabit connection.
+## Edit and adapt it to reflect your connection.
+##
+## You might want to change the connection type, ergo the interfaces you are using.
+##
+## Change testing to '0' to turn it from monitoring mode to active mode.
+
+config sqm-autorate 'main'
+        option download_interface 'ifb4pppoe-wan'
+        option upload_interface 'pppoe-wan'
+        option download_base_kbits '940000'
+        option upload_base_kbits '940000'
+        option download_min_percent '20'
+        option upload_min_percent '20'
+        option testing '1'
+        option log_level 'info'

--- a/sqm-autorate-rust/files/sqm-autorate.sample
+++ b/sqm-autorate-rust/files/sqm-autorate.sample
@@ -17,5 +17,5 @@ config sqm-autorate 'main'
         option upload_base_kbits '940000'
         option download_min_percent '20'
         option upload_min_percent '20'
-        option testing '1'
+#       option testing '1'  # Currently not suported by the rust binarry
         option log_level 'info'


### PR DESCRIPTION
## Description
This PR introduces a complete, robust OpenWrt packaging pipeline for the `sqm-autorate-rust` port. It implements proper `procd` supervision, FHS-compliant runtime data management, and an automated background updater with self-healing fallback logic.


I decided to write this PR against this repo and not against the `sqm-autorate-rust` repo because all those files are highly OpenWrt specify, ergo feel kinda out of place in the main repo and doing it here is more in line with OpenWrt packaging guidelines, at least according to my understanding

---

## 🛠 Key Changes

### 1. Build System & Package Bumps
* **Version Sync:** Bumped `PKG_RELEASE` to `2` and updated `PKG_SOURCE_VERSION` to the latest `master` (`7d833ec`).
* **Binary Alignment:** Corrected the binary installation path from `stripped` to `release` to align perfectly with current OpenWrt `rust-package.mk` macros.
* **Makefile Update:** Instructed the `Makefile` to pull the default fallback `reflectors-icmp.csv` directly from the source tree during compilation.

### 2. Robust Procd Init Wrapper
* **Init Script:** Implemented a standard OpenWrt `/etc/init.d/sqm-autorate` boot script.
* **Pre-flight Gatekeeping:** The init script strictly validates the existence of the UCI config, fallback ROM files, and target kernel network interfaces *before* hitting `procd_open_instance`. This complies with OpenWrt best practices and inherently prevents `procd` from triggering an infinite crash/respawn loop on broken setups.

### 3. FHS-Compliant Automated Updater (`sqm-autorate-update.sh`)
* **Cron Scheduling:** Includes a shell-based updater script triggered by a dynamic, randomized cron schedule (to distribute GitHub load).
* **Strict FHS Compliance & Atomicity:** Moves all volatile data cleanly into `/var/run/sqm-autorate/`. Temporary `.new` downloads are saved to the exact same `tmpfs` directory to guarantee standard `mv` commands perform true atomic kernel `rename()` syscalls, ensuring the rust binary never reads partial data.
  > *(Note: This should be impossible anyway given that the binary presumably reads the file on startup and keeps a copy in RAM, but better safe than sorry).*
* **Self-Healing Fallbacks:** Contains stale-file detection logic. If the live RAM reflector file inexplicably vanishes or is corrupted, the updater automatically fires `/etc/init.d/sqm-autorate restart`. This natively triggers the init-script gatekeeper, which seamlessly restores the fallback ROM copy to self-heal the service without user intervention.

### 4. UCI Configuration & `testing` Hook
* **Sample Config:** Provided a standard OpenWrt `sqm-autorate.sample` UCI configuration targeting symmetric gigabit connections.
* **Legacy Hooks:** Added native `sysv` parsing for the legacy Lua `testing '1'` (dry-run) variable. The OpenWrt feed script securely maps this and injects it into the environment as `SQMA_TESTING` for the Rust binary.

---

> [!NOTE]
> **To Upstream / Maintainers:** As an audit of the `0.2.0` rust source code confirms `SQMA_TESTING` is currently not supported natively in the binary( see https://github.com/Lochnair/sqm-autorate-rust/issues/46), the injection inside the init script has been cleanly commented out/stubbed as a placeholder. This PR can be considered **WIP** or merged as-is pending feedback on the roadmap for monitoring/dry-run capabilities in the backend!

> [!NOTE]
>  I have only quickly tested this, given that I don't have access to an environment where longer tests in active mode are a good idea (main connection of an 80 bed hostel).
> I wrote all this because I wanted to run sqm-autorotate in monitoring mode to figure out why I occasionally have bufferbloat issues and potentially tune it and then make it manage the connection over a static sqm config or to just fine-tune my static config.
> Super happy to test it properly and comprehensively if (as soon as) there's a way to start it in monitoring mode!